### PR TITLE
fix clojurescript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ In all cases, translation requests are logged upon fallback to fallback locale o
 #### ClojureScript translations (early support)
 
 ```clojure
+;; This example requires v3.1.0+
 (ns my-clojurescript-ns
   (:require [taoensso.tower :as tower :refer-macros (with-tscope)]))
 


### PR DESCRIPTION
I wasn't able to get the example running without the modifications made here.
`:require` statement has been simplified for CLJS > `2755` [1]. Let me know if I should add a comment about that.


1: https://groups.google.com/forum/#!topic/clojure/FoiqNV5nunQ